### PR TITLE
feat: Implement WebFlux Projects API with caching and observability. Fixes issue #9.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+logs/
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -86,13 +86,64 @@ To run the project locally using Docker:
 
 ## API Usage
 
-_The API usage commands will be available soon._
+_**Please note**: For proper API usage, we are still considering whether to use OpenAPI or Spring REST Docs. Your
+contribution is welcome._
+
+### Projects
+
+1. To create **one** or more projects, send a **POST** request:
+
+    ```bash
+    curl -X POST http://localhost:8080/api/v1/projects \
+         -H "Content-Type: application/json" \
+         -d '[
+               {
+                 "name": "Project 1",
+                 "requiredCapital": 100.00,
+                 "profit": 500.00
+               },
+               {
+                 "name": "Project 2",
+                 "requiredCapital": 200.00,
+                 "profit": 800.00
+               }
+             ]'
+    ```
 
 ---
 
 ## Observability Setup for Local Development
 
-_(Setup instructions will be available soon.)_
+1. **Start Observability Services**
+    ```bash
+    docker compose -f observability/compose.yaml up -d
+    ```
+
+### Log Monitoring
+
+1. **Access Grafana and configure Loki once the services are running**
+    - Verify that the services are both **running** and **healthy** by using `docker ps`
+    - Open Grafana at `http://localhost:3000` (default login: `admin` / `admin`).
+    - Navigate to **Data Sources**, click **"Add data source"** then Select **Loki**.
+    - Set the **URL** to `http://loki:3100` (thanks to Docker DNS), then click **"Save & Test"** to verify connectivity.
+
+2. **Create a Log Dashboard**
+    - Click the **"+"** in the top right, select **"New Dashboard"**, then click **"Add Visualization"**.
+    - Choose **Loki** as the data source.
+    - Use **Label Filters** to refine logs (e.g., service:roi-project-planner).
+    - Enable **Table View** to see structured log entries.
+
+3. **LogQL Queries for Analysis**
+    - **Calculate the rate of successful requests (status code 201) over the last 5 minutes:**
+       ```logql
+       rate({job="roi-project-planner-logs"} |~ "statusCode=201" | json [5m])
+       ```
+    - **Count the number of error logs over the last 30 minutes.**
+      ```logql
+      count_over_time({service="roi-project-planner", level="ERROR"} | json [30m])
+      ```
+
+    - Refer to the [LogQL documentation](https://grafana.com/docs/loki/latest/query) for advanced queries.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,62 +1,65 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.2'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.2'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.github'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(23)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(23)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2024.0.0")
+    set('logstashLogbackEncoderVersion', "8.0")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-cassandra-reactive'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
-	implementation 'org.springframework.cloud:spring-cloud-stream'
-	implementation 'org.springframework.cloud:spring-cloud-stream-binder-kafka'
-	implementation 'org.springframework.kafka:spring-kafka'
-	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.springframework.cloud:spring-cloud-stream-test-binder'
-	testImplementation 'org.springframework.kafka:spring-kafka-test'
-	testImplementation 'org.testcontainers:cassandra'
-	testImplementation 'org.testcontainers:junit-jupiter'
-	testImplementation 'org.testcontainers:kafka'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation "net.logstash.logback:logstash-logback-encoder:${logstashLogbackEncoderVersion}"
+    implementation 'org.springframework.boot:spring-boot-starter-data-cassandra-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
+    implementation 'org.springframework.cloud:spring-cloud-stream'
+    implementation 'org.springframework.cloud:spring-cloud-stream-binder-kafka'
+    implementation 'org.springframework.kafka:spring-kafka'
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.cloud:spring-cloud-stream-test-binder'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.testcontainers:cassandra'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:kafka'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
-	imageName = "ranzyblessingsdocker/roi-project-planner"
-	environment = ["BP_JVM_VERSION": "23.*"]
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
+    imageName = "ranzyblessingsdocker/roi-project-planner"
+    environment = ["BP_JVM_VERSION": "23.*"]
 }

--- a/config/cassandra-init-scripts/init.cql
+++ b/config/cassandra-init-scripts/init.cql
@@ -1,4 +1,4 @@
-CREATE KEYSPACE IF NOT EXISTS roi_project_planner WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+CREATE KEYSPACE IF NOT EXISTS roi_project_planner WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
 
 USE roi_project_planner;
 

--- a/observability/compose.yaml
+++ b/observability/compose.yaml
@@ -1,0 +1,55 @@
+services:
+
+  loki:
+    image: 'grafana/loki:3.1.2'
+    container_name: 'loki'
+    ports:
+      - '3100:3100'
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - observability-network
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "wget", "-qO-", "http://localhost:3100/metrics" ]
+      interval: 30s
+      retries: 3
+      timeout: 10s
+      start_period: 5s
+
+  promtail:
+    image: 'grafana/promtail:3.1.2'
+    container_name: 'promtail'
+    volumes:
+      - ./promtail-config.yaml:/etc/promtail/config.yml
+      - ../logs/application.log:/var/log/application.log
+    command: -config.file=/etc/promtail/config.yml
+    networks:
+      - observability-network
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "wget", "-qO-", "http://localhost:9080/metrics" ]
+      interval: 30s
+      retries: 3
+      timeout: 10s
+      start_period: 5s
+    depends_on:
+      loki:
+        condition: service_healthy
+
+  grafana:
+    image: 'grafana/grafana:11.5.1'
+    container_name: 'grafana'
+    ports:
+      - '3000:3000'
+    networks:
+      - observability-network
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/api/health" ]
+      interval: 30s
+      retries: 3
+      timeout: 10s
+      start_period: 5s
+
+networks:
+  observability-network:

--- a/observability/promtail-config.yaml
+++ b/observability/promtail-config.yaml
@@ -1,0 +1,31 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: roi-project-planner
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: roi-project-planner-logs
+          __path__: /var/log/application.log
+    pipeline_stages:
+      - json:
+          expressions:
+            timestamp: "'@timestamp'"
+            message: message
+            level: level
+            service: service
+      - timestamp:
+          source: timestamp
+          format: "RFC3339Nano"
+      - labels:
+          level:
+          service:

--- a/src/main/java/com/github/configuration/CacheConfiguration.java
+++ b/src/main/java/com/github/configuration/CacheConfiguration.java
@@ -1,0 +1,68 @@
+package com.github.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+    public static final String PROJECT_ID_CACHE_KEY = "project-id";
+
+    private final String redisHost;
+    private final Integer redisPort;
+
+    public CacheConfiguration(
+            @Value("${spring.data.redis.host}") String redisHost,
+            @Value("${spring.data.redis.port}") Integer redisPort) {
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+    }
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .commandTimeout(Duration.ofSeconds(5))
+                .shutdownTimeout(Duration.ZERO)
+                .build();
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort), clientConfig);
+    }
+
+    @Bean
+    ReactiveRedisTemplate<String, String> reactiveRedisTemplate(ReactiveRedisConnectionFactory connectionFactory) {
+        return new ReactiveRedisTemplate<>(connectionFactory, RedisSerializationContext.string());
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues();
+
+        RedisCacheConfiguration commonCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues();
+
+        Map<String, RedisCacheConfiguration> initialCacheConfigs =
+                Collections.singletonMap(PROJECT_ID_CACHE_KEY, commonCacheConfig);
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultCacheConfig)
+                .withInitialCacheConfigurations(initialCacheConfigs)
+                .transactionAware()
+                .build();
+    }
+}

--- a/src/main/java/com/github/projects/api/ApiResponse.java
+++ b/src/main/java/com/github/projects/api/ApiResponse.java
@@ -1,0 +1,59 @@
+package com.github.projects.api;
+
+/**
+ * Standardized API response wrapper for consistent structure. Includes HTTP status, message, and data.
+ * Immutable and thread-safe.
+ *
+ * @param <T> The data type of the response payload.
+ */
+public final class ApiResponse<T> {
+    private final int statusCode;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(int statusCode, String message, T data) {
+        if (statusCode < 100 || statusCode > 599) {
+            throw new IllegalArgumentException(String.format("Invalid HTTP status code: %d", statusCode));
+        }
+        this.statusCode = statusCode;
+        this.message = message;
+        this.data = data;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    /**
+     * Creates a success response with the provided HTTP status code and data.
+     */
+    public static <T> ApiResponse<T> success(int statusCode, T data) {
+        if (data == null) {
+            throw new IllegalArgumentException("Success response data cannot be null");
+        }
+        return new ApiResponse<>(statusCode, null, data);
+    }
+
+    /**
+     * Creates an error response with the provided HTTP status code and the error message.
+     */
+    public static <T> ApiResponse<T> error(int statusCode, String message) {
+        if (message == null || message.isEmpty()) {
+            throw new IllegalArgumentException("Error response message cannot be null or empty");
+        }
+        return new ApiResponse<>(statusCode, message, null);
+    }
+
+    @Override
+    public String toString() {
+        return "ApiResponse{statusCode=%d, message='%s', data=%s}".formatted(statusCode, message, data);
+    }
+}

--- a/src/main/java/com/github/projects/api/CreateProjectRequest.java
+++ b/src/main/java/com/github/projects/api/CreateProjectRequest.java
@@ -1,0 +1,24 @@
+package com.github.projects.api;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+/**
+ * Request DTO for creating a new project.
+ */
+public record CreateProjectRequest(
+        @NotBlank(message = "Project name cannot be blank")
+        String name,
+
+        @NotNull(message = "The capital required to start the project cannot be null")
+        @DecimalMin(value = "0.00", message = "Required capital must be greater than or equal to 0")
+        BigDecimal requiredCapital,
+
+        @NotNull(message = "Expected project profit cannot be null")
+        @DecimalMin(value = "0.00", message = "Profit must be greater than or equal to 0")
+        BigDecimal profit
+) {
+}

--- a/src/main/java/com/github/projects/api/ProjectService.java
+++ b/src/main/java/com/github/projects/api/ProjectService.java
@@ -1,0 +1,51 @@
+package com.github.projects.api;
+
+import com.github.projects.model.ProjectDTO;
+import com.github.projects.model.ProjectEntity;
+import com.github.projects.model.ProjectRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.Collection;
+import java.util.NoSuchElementException;
+
+import static com.github.configuration.CacheConfiguration.PROJECT_ID_CACHE_KEY;
+import static com.github.projects.model.Validators.requireNonNullAndNoNullElements;
+
+/**
+ * Service for managing project persistence.
+ */
+@Service
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+
+    public ProjectService(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    /**
+     * Save multiple projects to the repository.
+     */
+    public Flux<ProjectDTO> addAll(Iterable<ProjectEntity> projects) {
+        return Mono.fromCallable(() -> {
+                    requireNonNullAndNoNullElements((Collection<ProjectEntity>) projects, () -> "Projects cannot be null or empty");
+                    return projects;
+                })
+                .subscribeOn(Schedulers.boundedElastic()) // Offload to a thread pool for blocking operations
+                .flatMapMany(projectRepository::saveAll)
+                .map(ProjectDTO::fromEntity);
+    }
+
+    /**
+     * Retrieves a project by its ID from the repository, with caching for improved performance.
+     */
+    @Cacheable(value = PROJECT_ID_CACHE_KEY, key = "#id")
+    public Mono<ProjectDTO> findById(String id) {
+        return projectRepository.findById(id)
+                .switchIfEmpty(Mono.error(new NoSuchElementException("Project not found for ID: %s".formatted(id))))
+                .map(ProjectDTO::fromEntity);
+    }
+}

--- a/src/main/java/com/github/projects/api/ProjectsApiController.java
+++ b/src/main/java/com/github/projects/api/ProjectsApiController.java
@@ -1,0 +1,56 @@
+package com.github.projects.api;
+
+import com.github.projects.model.ProjectDTO;
+import com.github.projects.model.ProjectEntity;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "/api/v1/projects")
+public class ProjectsApiController {
+    private static final Logger logger = LoggerFactory.getLogger(ProjectsApiController.class);
+
+    private final ProjectService projectService;
+
+    public ProjectsApiController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Mono<ApiResponse<List<ProjectDTO>>> createProjects(
+            @Valid @RequestBody Flux<CreateProjectRequest> requestFlux) {
+        logger.info("Received request to create new projects");
+
+        return requestFlux
+                .doOnNext(request -> logger.debug("Processing project: {}", request))
+                .map(this::toProjectEntity)
+                .collectList()
+                .flatMap(this::saveProjects)
+                .doOnError(error -> logger.error("Error occurred while creating projects", error));
+    }
+
+    private ProjectEntity toProjectEntity(CreateProjectRequest request) {
+        return ProjectEntity.createNewProject(request.name(), request.requiredCapital(), request.profit());
+    }
+
+    private Mono<ApiResponse<List<ProjectDTO>>> saveProjects(List<ProjectEntity> projects) {
+        logger.info("Saving {} projects", projects.size());
+
+        return projectService.addAll(projects)
+                .collectList()
+                .map(result -> {
+                    var response = ApiResponse.success(HttpStatus.CREATED.value(), result);
+                    logger.info("Successfully created {} projects: ApiResponse(statusCode={}, data={})",
+                            result.size(), response.getStatusCode(), response.getData());
+                    return response;
+                });
+    }
+}

--- a/src/main/java/com/github/projects/api/ProjectsApiExceptionHandler.java
+++ b/src/main/java/com/github/projects/api/ProjectsApiExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.github.projects.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import reactor.core.publisher.Mono;
+
+import java.util.stream.Collectors;
+
+/**
+ * Centralized exception handler for REST API endpoints, providing uniform error responses.
+ */
+@RestControllerAdvice
+public class ProjectsApiExceptionHandler {
+
+    @ExceptionHandler(WebExchangeBindException.class)
+    public Mono<ResponseEntity<ApiResponse<String>>> handleValidationExceptions(WebExchangeBindException ex) {
+        var errorMessages = collectErrorMessages(ex);
+
+        final var httpStatus = HttpStatus.BAD_REQUEST;
+        var response = ApiResponse.<String>error(httpStatus.value(), errorMessages);
+        return Mono.just(new ResponseEntity<>(response, httpStatus));
+    }
+
+    private static String collectErrorMessages(WebExchangeBindException ex) {
+        return ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> String.format("%s: %s", error.getField(), error.getDefaultMessage()))
+                .collect(Collectors.joining(", "));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public Mono<ResponseEntity<ApiResponse<String>>> handleGenericException(Exception ex) {
+        final var httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        var response = ApiResponse.<String>error(httpStatus.value(), ex.getMessage());
+        return Mono.just(new ResponseEntity<>(response, httpStatus));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,12 @@ spring:
     keyspace-name: roi_project_planner
     contact-points: localhost:9042
     local-datacenter: dc1
+    consistency-level: ONE # For dev
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 management:
   endpoints:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+
+    <springProperty scope="context" name="LOG_PATH" source="LOG_PATH" defaultValue="logs"/>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeCallerData>true</includeCallerData>
+            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</timestampPattern>
+            <customFields>{"service":"roi-project-planner"}</customFields>
+            <provider class="net.logstash.logback.composite.loggingevent.MdcJsonProvider"/>
+            <provider class="net.logstash.logback.composite.loggingevent.StackTraceJsonProvider">
+                <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                    <maxDepthPerThrowable>10</maxDepthPerThrowable>
+                    <maxLength>2048</maxLength>
+                    <shortenedClassNameLength>20</shortenedClassNameLength>
+                </throwableConverter>
+            </provider>
+        </encoder>
+    </appender>
+
+    <appender name="FileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/application.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/application.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeCallerData>true</includeCallerData>
+            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</timestampPattern>
+            <customFields>{"service":"roi-project-planner"}</customFields>
+            <provider class="net.logstash.logback.composite.loggingevent.MdcJsonProvider"/>
+            <provider class="net.logstash.logback.composite.loggingevent.StackTraceJsonProvider">
+                <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                    <maxDepthPerThrowable>10</maxDepthPerThrowable>
+                    <maxLength>2048</maxLength>
+                    <shortenedClassNameLength>20</shortenedClassNameLength>
+                </throwableConverter>
+            </provider>
+        </encoder>
+    </appender>
+
+    <appender name="AsyncConsole" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="Console"/>
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+    </appender>
+
+    <appender name="AsyncFileAppender" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FileAppender"/>
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+    </appender>
+
+    <appender name="FallbackConsole" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level [%thread]: %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="AsyncFileAppender"/>
+    </root>
+
+    <logger name="com.github" level="DEBUG" additivity="false">
+        <appender-ref ref="AsyncFileAppender"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="AsyncConsole"/>
+        <appender-ref ref="FallbackConsole"/>
+    </root>
+
+    <logger name="com.github" level="INFO" additivity="false">
+        <appender-ref ref="AsyncConsole"/>
+    </logger>
+
+</configuration>

--- a/src/test/java/com/github/RoiProjectPlannerApplicationTest.java
+++ b/src/test/java/com/github/RoiProjectPlannerApplicationTest.java
@@ -1,26 +1,11 @@
 package com.github;
 
-import com.github.configuration.CassandraTestSetup;
 import com.github.configuration.TestcontainersConfiguration;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.cassandra.core.ReactiveCassandraOperations;
 
 @SpringBootTest
 class RoiProjectPlannerApplicationTest extends TestcontainersConfiguration {
-    private final CassandraTestSetup cassandraTestSetup;
-
-    @Autowired
-    RoiProjectPlannerApplicationTest(ReactiveCassandraOperations reactiveCassandraOperations) {
-        this.cassandraTestSetup = new CassandraTestSetup(reactiveCassandraOperations);
-    }
-
-    @BeforeEach
-    void setUp() {
-        cassandraTestSetup.setup();
-    }
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/github/projects/api/ProjectServiceCachingTest.java
+++ b/src/test/java/com/github/projects/api/ProjectServiceCachingTest.java
@@ -1,0 +1,73 @@
+package com.github.projects.api;
+
+import com.github.configuration.TestcontainersConfiguration;
+import com.github.projects.model.AuditMetadata;
+import com.github.projects.model.ProjectDTO;
+import com.github.projects.model.ProjectEntity;
+import com.github.projects.model.ProjectRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+
+import static com.github.configuration.CacheConfiguration.PROJECT_ID_CACHE_KEY;
+import static java.util.UUID.randomUUID;
+
+@Testcontainers
+@SpringBootTest
+class ProjectServiceCachingTest extends TestcontainersConfiguration {
+
+    @MockitoBean
+    private ProjectRepository projectRepository;
+
+    private final CacheManager cacheManager;
+    private final ProjectService projectService;
+
+    private ProjectEntity projectEntity;
+
+    @Autowired
+    public ProjectServiceCachingTest(CacheManager cacheManager, ProjectService projectService) {
+        this.cacheManager = cacheManager;
+        this.projectService = projectService;
+    }
+
+    @BeforeEach
+    void setUp() {
+        final Cache usersCache = cacheManager.getCache(PROJECT_ID_CACHE_KEY);
+        if (usersCache != null) {
+            usersCache.clear();
+        }
+
+        projectEntity = new ProjectEntity(randomUUID(), "Project 1", new BigDecimal("100.00"),
+                new BigDecimal("300"), AuditMetadata.empty(), 0L);
+    }
+
+    @Test
+    void testFindById_shouldCacheResult() {
+        Mockito.when(projectRepository.findById(Mockito.anyString())).thenReturn(Mono.just(projectEntity));
+
+        // Given: A specific project ID
+        final var projectID = "1";
+
+        // When: Invoking the service method twice, expecting the result to be cached after the initial invocation
+        ProjectDTO firstInvocationResult = projectService.findById(projectID).block();
+        ProjectDTO secondInvocationResult = projectService.findById(projectID).block();
+
+        // Then: Assert that both invocations return the same cached result, without querying the repository again.
+        Assertions.assertThat(firstInvocationResult).isNotNull();
+        Assertions.assertThat(secondInvocationResult).isNotNull();
+        Assertions.assertThat(firstInvocationResult).isEqualTo(secondInvocationResult);
+
+        // Verify that the repository was queried only once, confirming the caching mechanism.
+        Mockito.verify(projectRepository, Mockito.times(1)).findById(Mockito.anyString());
+    }
+}

--- a/src/test/java/com/github/projects/api/ProjectServiceTest.java
+++ b/src/test/java/com/github/projects/api/ProjectServiceTest.java
@@ -1,0 +1,131 @@
+package com.github.projects.api;
+
+import com.github.projects.model.AuditMetadata;
+import com.github.projects.model.ProjectDTO;
+import com.github.projects.model.ProjectEntity;
+import com.github.projects.model.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static java.util.UUID.randomUUID;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    private ProjectEntity projectEntity1;
+    private ProjectEntity projectEntity2;
+
+    @BeforeEach
+    void setUp() {
+        // Set up sample project entities
+        projectEntity1 = new ProjectEntity(randomUUID(), "Project 1", BigDecimal.ZERO, BigDecimal.ONE, AuditMetadata.empty(), 0L);
+        projectEntity2 = new ProjectEntity(randomUUID(), "Project 2", BigDecimal.ONE, BigDecimal.TWO, AuditMetadata.empty(), 0L);
+    }
+
+    @Test
+    void testAddAll_Success() {
+        // Given
+        Iterable<ProjectEntity> projects = List.of(projectEntity1, projectEntity2);
+
+        when(projectRepository.saveAll(projects)).thenReturn(Flux.just(projectEntity1, projectEntity2));
+
+        // When
+        Flux<ProjectDTO> result = projectService.addAll(projects);
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(projectDTO -> projectDTO.name().equals("Project 1"))
+                .expectNextMatches(projectDTO -> projectDTO.name().equals("Project 2"))
+                .verifyComplete();
+
+        verify(projectRepository).saveAll(projects);
+    }
+
+    @Test
+    void testAddAll_EmptyCollection() {
+        // Given
+        Iterable<ProjectEntity> emptyProjects = Collections.emptyList();
+
+        // When
+        Flux<ProjectDTO> result = projectService.addAll(emptyProjects);
+
+        // Then
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof IllegalArgumentException
+                        && throwable.getMessage().equals("Projects cannot be null or empty"))
+                .verify();
+    }
+
+    @Test
+    void testAddAll_NullCollection() {
+        // Given
+        Iterable<ProjectEntity> nullProjects = null;
+
+        // When
+        Flux<ProjectDTO> result = projectService.addAll(nullProjects);
+
+        // Then
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof NullPointerException
+                        && throwable.getMessage().equals("Projects cannot be null or empty"))
+                .verify();
+    }
+
+    @Test
+    void testFindById_ProjectFound() {
+        // Given
+        String projectId = "1";
+
+        when(projectRepository.findById(projectId)).thenReturn(Mono.just(projectEntity1));
+
+        // When
+        Mono<ProjectDTO> result = projectService.findById(projectId);
+
+        // Then
+        StepVerifier.create(result)
+                .expectNextMatches(projectDTO -> projectDTO.name().equals("Project 1"))
+                .verifyComplete();
+
+        Mockito.verify(projectRepository).findById(projectId);
+    }
+
+    @Test
+    void testFindById_ProjectNotFound() {
+        // Given
+        String projectId = "2";
+
+        when(projectRepository.findById(projectId)).thenReturn(Mono.empty());
+
+        // When
+        Mono<ProjectDTO> result = projectService.findById(projectId);
+
+        // Then
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof NoSuchElementException
+                        && throwable.getMessage().contains("Project not found for ID: 2"))
+                .verify();
+
+        Mockito.verify(projectRepository).findById(projectId);
+    }
+}

--- a/src/test/java/com/github/projects/api/ProjectsApiControllerTest.java
+++ b/src/test/java/com/github/projects/api/ProjectsApiControllerTest.java
@@ -1,0 +1,67 @@
+package com.github.projects.api;
+
+import com.github.projects.model.AuditMetadata;
+import com.github.projects.model.ProjectDTO;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+
+import java.math.BigDecimal;
+
+import static java.util.UUID.randomUUID;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+@WebFluxTest(ProjectsApiController.class)
+class ProjectsApiControllerTest {
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    @InjectMocks
+    private ProjectsApiController projectsApiController;
+
+    private final WebTestClient webTestClient;
+
+    @Autowired
+    ProjectsApiControllerTest(WebTestClient webTestClient) {
+        this.webTestClient = webTestClient;
+    }
+
+    @Test
+    void testCreateNewProjects_Success() {
+        // Given
+        var request1 = new CreateProjectRequest("Project 1", new BigDecimal("100.00"), new BigDecimal("500.00"));
+        var request2 = new CreateProjectRequest("Project 2", new BigDecimal("150.00"), new BigDecimal("800.00"));
+
+        Flux<CreateProjectRequest> requestFlux = Flux.just(request1, request2);
+
+        // ProjectDTO mock return
+        var projectDTO1 = new ProjectDTO(randomUUID(), "Project 1", new BigDecimal("100.00"), new BigDecimal("500.00"), AuditMetadata.empty(), 0L);
+        var projectDTO2 = new ProjectDTO(randomUUID(), "Project 2", new BigDecimal("150.00"), new BigDecimal("800.00"), AuditMetadata.empty(), 0L);
+
+        // Mock the service call to return a Flux of ProjectDTO
+        when(projectService.addAll(anyList())).thenReturn(Flux.just(projectDTO1, projectDTO2));
+
+        // When & Then
+        webTestClient.post()
+                .uri("/api/v1/projects")
+                .body(requestFlux, Flux.class)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody()
+                .jsonPath("$.statusCode").isEqualTo("201")
+                .jsonPath("$.data[0].id").isNotEmpty()
+                .jsonPath("$.data[0].name").isEqualTo("Project 1")
+                .jsonPath("$.data[0].requiredCapital").isEqualTo(100.00)
+                .jsonPath("$.data.[0].profit").isEqualTo(500.00)
+                .jsonPath("$.data.[1].id").isNotEmpty()
+                .jsonPath("$.data.[1].name").isEqualTo("Project 2")
+                .jsonPath("$.data.[1].requiredCapital").isEqualTo(150.00)
+                .jsonPath("$.data.[1].profit").isEqualTo(800.00);
+    }
+}


### PR DESCRIPTION
This commit introduces a Spring WebFlux ProjectsApiController to expose an API endpoint for creating projects, along with Redis caching for lookups to improve performance and scalability.  Project data is validated before persistence, with invalid data returning appropriate HTTP error responses. Successful creation returns 201 Created.

Key changes:

*   Implemented `ProjectsApiController` with create project endpoint.
*   Added Redis caching for project lookups (configurable TTL, eviction).
*   Implemented project data validation with appropriate error responses.
*   Added comprehensive unit and integration tests.
*   Configured Logback to output logs in JSON format for Loki ingestion.
*   Setup local development observability stack with Loki, Promtail, and Grafana using Docker Compose.

This enhancement provides a more robust and performant API for managing projects and lays the foundation for advanced monitoring and analysis.