### PR TITLE
Write integration tests for Kafka Publisher and Consumer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.testcontainers:cassandra'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.testcontainers:kafka'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/test/java/com/github/analytics/api/ProjectCapitalOptimizerTest.java
+++ b/src/test/java/com/github/analytics/api/ProjectCapitalOptimizerTest.java
@@ -1,8 +1,5 @@
-package com.github.analytics;
+package com.github.analytics.api;
 
-import com.github.analytics.api.CapitalMaximizationQuery;
-import com.github.analytics.api.ProjectCapitalOptimized;
-import com.github.analytics.api.ProjectCapitalOptimizer;
 import com.github.projects.model.AuditMetadata;
 import com.github.projects.model.ProjectDTO;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/analytics/event/ProjectCapitalOptimizerIntegrationTest.java
+++ b/src/test/java/com/github/analytics/event/ProjectCapitalOptimizerIntegrationTest.java
@@ -1,0 +1,71 @@
+package com.github.analytics.event;
+
+import com.github.analytics.api.CapitalMaximizationQuery;
+import com.github.analytics.api.ProjectCapitalOptimized;
+import com.github.analytics.api.ProjectCapitalOptimizer;
+import com.github.configuration.TestcontainersConfiguration;
+import com.github.projects.api.ProjectService;
+import com.github.projects.model.AuditMetadata;
+import com.github.projects.model.ProjectDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.UUID.randomUUID;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ProjectCapitalOptimizerIntegrationTest extends TestcontainersConfiguration {
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    @MockitoBean
+    private ProjectCapitalOptimizer projectCapitalOptimizer;
+
+    private final ProjectCapitalOptimizerEventPublisher publisher;
+
+    @Autowired
+    ProjectCapitalOptimizerIntegrationTest(ProjectCapitalOptimizerEventPublisher publisher) {
+        this.publisher = publisher;
+    }
+
+    @Test
+    void givenValidEvent_whenPublished_thenConsumerProcessesEventSuccessfully() {
+
+        // Given: A valid event and mocked dependencies
+        var event = new CapitalMaximizationQueryEvent(2, new BigDecimal("100"));
+
+        var project = new ProjectDTO(randomUUID(), "Project 1", new BigDecimal("100.00"),
+                new BigDecimal("500.00"), AuditMetadata.empty(), 0L);
+        var optimized = new ProjectCapitalOptimized(List.of(project), new BigDecimal("500.00"));
+
+        when(projectService.findAll()).thenReturn(Flux.just(project));
+        when(projectCapitalOptimizer.maximizeCapital(any(CapitalMaximizationQuery.class))).thenReturn(Mono.just(optimized));
+
+        // When: Event is published to Kafka topic
+        var publishEventMono = publisher.publishEvent(event);
+
+        // Then: Verify event is published successfully
+        StepVerifier.create(publishEventMono)
+                .expectNext(Boolean.TRUE)
+                .verifyComplete();
+
+        // Then: Ensure consumer processes the event and invokes expected methods
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(projectService, times(1)).findAll();
+            verify(projectCapitalOptimizer, times(1))
+                    .maximizeCapital(any(CapitalMaximizationQuery.class));
+        });
+    }
+}

--- a/src/test/java/com/github/configuration/TestcontainersConfiguration.java
+++ b/src/test/java/com/github/configuration/TestcontainersConfiguration.java
@@ -4,10 +4,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Import;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.CassandraContainer;
@@ -19,9 +18,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 @Import(CassandraConfiguration.class)
-@EnableAutoConfiguration(exclude = {
-        KafkaAutoConfiguration.class
-})
+@EmbeddedKafka(ports = 9092, kraft = true)
 public abstract class TestcontainersConfiguration {
     private static final Logger logger = LoggerFactory.getLogger(TestcontainersConfiguration.class.getName());
     private static final int REDIS_PORT = 6379;


### PR DESCRIPTION
- Implement integration tests to verify the Kafka Publisher successfully publishes events.
- Add tests for the Kafka Consumer to ensure events are processed correctly.
- Mock necessary dependencies (ProjectService, ProjectCapitalOptimizer) for testing the event flow.
- Ensure that event publication and consumption are correctly verified within the test.

Fixes #26