### PR TITLE
feat(ci): Integrate Trivy for Docker image vulnerability scanning Fixes #24

### DIFF
--- a/.github/workflows/build-test-dockerize-deploy.yml
+++ b/.github/workflows/build-test-dockerize-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build and test the application with Gradle
         run: ./gradlew clean build  # This will build and run tests in one command
 
-  # Job to build the Docker image using Spring Boot Buildpacks and push it to Docker Hub
+  # Job to build the Docker image using Cloud Native Buildpacks, scan it for vulnerabilities with Trivy, and push it to Docker Hub
   dockerize_and_deploy_image:
     runs-on: ubuntu-latest
     needs: build_and_test_application  # Ensure this job only runs after successful build and tests

--- a/.github/workflows/build-test-dockerize-deploy.yml
+++ b/.github/workflows/build-test-dockerize-deploy.yml
@@ -69,6 +69,14 @@ jobs:
           ./gradlew bootBuildImage --imageName=$TAG_LATEST
           ./gradlew bootBuildImage --imageName=$TAG_SHA
 
+      - name: Scan Docker image for vulnerabilities with Trivy
+        uses: aquasecurity/trivy-action@v0.29.0
+        with:
+          image-ref: 'ranzyblessingsdocker/roi-project-planner:latest'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+
       - name: Push the Docker image to Docker Hub
         run: |
           IMAGE_NAME="ranzyblessingsdocker/roi-project-planner"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Return On Investment (ROI) Project Planner
+# Return On Investment Project Planner
 
 ## Overview
 


### PR DESCRIPTION
- Added Trivy to GitHub Actions workflow to scan Docker images for vulnerabilities.
- Configured Trivy to scan the built image before pushing to Docker Hub.
- Set severity threshold to CRITICAL,HIGH with exit code 1 for pipeline enforcement.
- Pinned Trivy GitHub Action to v0.29.0 for stability and consistency.

Ensures security compliance by preventing deployment of vulnerable images.

Fixes #24 