### PR TITLE
chore(ci): Update Trivy configuration and fix Testcontainers import

### DIFF
--- a/.github/workflows/build-test-dockerize-deploy.yml
+++ b/.github/workflows/build-test-dockerize-deploy.yml
@@ -70,12 +70,14 @@ jobs:
           ./gradlew bootBuildImage --imageName=$TAG_SHA
 
       - name: Scan Docker image for vulnerabilities with Trivy
-        uses: aquasecurity/trivy-action@v0.29.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: 'ranzyblessingsdocker/roi-project-planner:latest'
           format: 'table'
-          severity: 'CRITICAL,HIGH'
           exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
 
       - name: Push the Docker image to Docker Hub
         run: |

--- a/src/test/java/com/github/configuration/TestcontainersConfiguration.java
+++ b/src/test/java/com/github/configuration/TestcontainersConfiguration.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
@@ -25,8 +25,8 @@ public abstract class TestcontainersConfiguration {
 
     @Container
     @ServiceConnection
-    private static final CassandraContainer<?> CASSANDRA_CONTAINER =
-            new CassandraContainer<>(DockerImageName.parse("cassandra:5.0.3"))
+    private static final CassandraContainer CASSANDRA_CONTAINER =
+            new CassandraContainer(DockerImageName.parse("cassandra:5.0.3"))
                     .waitingFor(Wait.forListeningPort())
                     .withExposedPorts(9042);
 


### PR DESCRIPTION
- Updated Trivy GitHub Action from v0.29.0 to v0.28.0 to align with workflow requirements.
- Added `ignore-unfixed` and `vuln-type` options to Trivy scan for enhanced vulnerability filtering.
- Refined Trivy scan to include both OS and library vulnerabilities with specified severity.
- Fixed incorrect import for Cassandra container in Testcontainers configuration (from `org.testcontainers.containers.CassandraContainer` to `org.testcontainers.cassandra.CassandraContainer`).

Ensures improved security scanning and proper container configuration in tests.