### PR TITLE
chore: improve Cassandra init by using a dedicated build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To run the project locally using Docker, follow these steps:
     ```
 2. **Start Dependencies with Docker Compose:**
    ```bash
-      docker compose up -d
+      docker compose up --build -d
    ```
 
    **Note:** This command will start the following services:

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,7 +56,8 @@ services:
       timeout: 10s
 
   cassandra-init:
-    image: 'python:3.9-slim-buster'
+    image: 'cassandra-init:latest'
+    build: ./config/cassandra-init-scripts
     container_name: 'cassandra-init'
     depends_on:
       cassandra:
@@ -65,17 +66,6 @@ services:
       - ./config/cassandra-init-scripts:/scripts
     networks:
       - dev-network
-    entrypoint:
-      - sh
-      - -c
-      - |
-        apt-get update && apt-get install -y netcat-openbsd;
-        pip install cassandra-driver;
-        while ! nc -zv cassandra 9042; do
-          echo "Waiting for Cassandra to be available...";
-          sleep 1;
-        done;
-        python3 /scripts/init_cassandra.py
     restart: no
 
   redis:

--- a/config/cassandra-init-scripts/Dockerfile
+++ b/config/cassandra-init-scripts/Dockerfile
@@ -1,0 +1,15 @@
+# Use a minimal Python image
+FROM python:3.9-slim-buster
+
+# Install required packages
+RUN apt-get update && apt-get install -y netcat-openbsd && \
+    pip install cassandra-driver
+
+# Set working directory
+WORKDIR /scripts
+
+# Copy init script into container
+COPY init_cassandra.py /scripts/init_cassandra.py
+
+# Entrypoint command: wait for Cassandra to be ready, then execute the script
+CMD sh -c "while ! nc -zv cassandra 9042; do echo 'Waiting for Cassandra...'; sleep 1; done; python3 /scripts/init_cassandra.py"


### PR DESCRIPTION
- Refactored `cassandra-init` service in `compose.yaml` to use a dedicated Docker image (`cassandra-init:latest`) instead of inline commands.
- Added `build` configuration to pre-install `cassandra-driver`, eliminating redundant installations and reducing startup time.
- Removed inline `entrypoint` logic from `compose.yaml` for better maintainability and efficiency.
- Updated `README.md` to use `docker compose up --build -d`, ensuring changes to the Cassandra init container are applied.

This improves reliability, optimizes startup performance, and aligns with best practices for Docker-based service initialization.