### PR TITLE
Remove unnecessary Cassandra volume and add missing init script

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -62,8 +62,6 @@ services:
     depends_on:
       cassandra:
         condition: service_healthy
-    volumes:
-      - ./config/cassandra-init-scripts:/scripts
     networks:
       - dev-network
     restart: no

--- a/config/cassandra-init-scripts/Dockerfile
+++ b/config/cassandra-init-scripts/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y netcat-openbsd && \
 # Set working directory
 WORKDIR /scripts
 
-# Copy init script into container
+# Copy init scripts into container
+COPY init.cql /scripts/init.cql
 COPY init_cassandra.py /scripts/init_cassandra.py
 
 # Entrypoint command: wait for Cassandra to be ready, then execute the script


### PR DESCRIPTION
- Removed the `volumes` section in `compose.yaml` for Cassandra init scripts, as it is no longer needed.
- Added `init.cql` to the Dockerfile to ensure proper initialization of Cassandra.