### PR TITLE
feat(resilience): Add caching and resilience mechanisms for project retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,43 +90,43 @@ contribution is welcome._
 
 ### Projects
 
-1. To **create one or more projects**, send a **POST** request:
+To **create one or more projects**, send a **POST** request:
 
-    ```bash
-    curl -X POST http://localhost:8080/api/v1/projects \
-         -H "Content-Type: application/json" \
-         -d '[
-               {
-                 "name": "Project 1",
-                 "requiredCapital": 0.00,
-                 "profit": 100.00
-               },
-               {
-                 "name": "Project 2",
-                 "requiredCapital": 100.00,
-                 "profit": 200.00
-               },
-               {
-                 "name": "Project 3",
-                 "requiredCapital": 100.00,
-                 "profit": 300.00
-               }
-             ]'
-    ```
+ ```bash
+ curl -X POST http://localhost:8080/api/v1/projects \
+      -H "Content-Type: application/json" \
+      -d '[
+            {
+              "name": "Project 1",
+              "requiredCapital": 0.00,
+              "profit": 100.00
+            },
+            {
+              "name": "Project 2",
+              "requiredCapital": 100.00,
+              "profit": 200.00
+            },
+            {
+              "name": "Project 3",
+              "requiredCapital": 100.00,
+              "profit": 300.00
+            }
+          ]'
+ ```
 
 ### Project Capital Maximization
 
-1. To **maximize capital** by selecting up to _k_ distinct projects from a pool of available projects, send a **POST**
-   request:
+To **maximize capital** by selecting up to _k_ distinct projects from a pool of available projects, send a **POST**
+request:
 
-    ```bash
-    curl -X POST http://localhost:8080/api/v1/capital/maximization/query \
-         -H "Content-Type: application/json" \
-         -d '{
-              "maxProjects":2,
-              "initialCapital":"100.00" 
-            }'
-    ```
+ ```bash
+ curl -X POST http://localhost:8080/api/v1/capital/maximization/query \
+      -H "Content-Type: application/json" \
+      -d '{
+           "maxProjects":2,
+           "initialCapital":"100.00" 
+         }'
+ ```
 
 For now, to **view selected projects and capital maximization**, use Grafana as outlined
 in [Observability Setup for Local Development](#observability-setup-for-local-development) under the
@@ -134,6 +134,23 @@ in [Observability Setup for Local Development](#observability-setup-for-local-de
 
 _In the future, advanced analytics and graphical representations will be added, with support for custom views that
 consumers can subscribe to for tailored visualizations._
+
+### List all projects
+
+To **retrieve all projects**, send a **GET** request:
+
+```bash
+curl http://localhost:8080/api/v1/projects
+```
+
+### List project by ID
+
+To **retrieve a project** by its unique identifier, send a **GET** request with the project **ID**. Subsequent requests
+are faster due to **caching**.
+
+```bash
+curl http://localhost:8080/api/v1/projects/{ID}
+```
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 ext {
     set('springCloudVersion', "2024.0.0")
     set('logstashLogbackEncoderVersion', "8.0")
+    set('resilience4jVersion', "2.2.0")
     set('jacksonDatatypeJsr310Version', "2.18.2")
 }
 
@@ -48,6 +49,7 @@ dependencies {
 
     // Add-ons
     implementation "net.logstash.logback:logstash-logback-encoder:${logstashLogbackEncoderVersion}"
+    implementation "io.github.resilience4j:resilience4j-spring-boot3"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonDatatypeJsr310Version}"
     implementation 'io.netty:netty-handler:4.1.118.Final' // patch to resolve CVE-2025-24970
 
@@ -68,6 +70,7 @@ dependencies {
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+        mavenBom "io.github.resilience4j:resilience4j-bom:${resilience4jVersion}"
     }
 }
 

--- a/src/main/java/com/github/projects/exception/CriticalServiceFailureException.java
+++ b/src/main/java/com/github/projects/exception/CriticalServiceFailureException.java
@@ -1,0 +1,15 @@
+package com.github.projects.exception;
+
+/**
+ * Exception thrown when a critical service failure occurs, indicating an unrecoverable error.
+ */
+public class CriticalServiceFailureException extends RuntimeException {
+
+    public CriticalServiceFailureException(String message) {
+        super(message);
+    }
+
+    public CriticalServiceFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/github/projects/exception/TransientException.java
+++ b/src/main/java/com/github/projects/exception/TransientException.java
@@ -1,0 +1,15 @@
+package com.github.projects.exception;
+
+/**
+ * Exception thrown when a transient error occurs, indicating it may be retried.
+ */
+public class TransientException extends RuntimeException {
+
+    public TransientException(String message) {
+        super(message);
+    }
+
+    public TransientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,36 @@ spring:
             backOffMultiplier: 2.0
             partitioned: true
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      projects:
+        allowHealthIndicatorToFail: false
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10000
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        ignoreExceptions:
+          - com.github.analytics.exception.InvalidCapitalMaximizationQueryException
+          - com.github.projects.exception.InvalidProjectException
+          - com.github.projects.exception.ProjectNotFoundException
+          - com.github.projects.exception.TooManyProjectsException
+          - com.github.projects.exception.TransientException
+  timelimiter:
+    instances:
+      projects:
+        timeoutDuration: 2s
+  retry:
+    instances:
+      projects:
+        maxAttempts: 3
+        waitDuration: 1000
+        retryExceptions:
+          - com.github.projects.exception.TransientException
+
 management:
   endpoints:
     web:
@@ -61,6 +91,9 @@ management:
     exporter:
       zipkin:
         endpoint: http://localhost:9411/api/v2/spans # Exports trace data to Jaeger via Zipkin API.
+  health:
+    circuitbreakers:
+      enabled: true
 
 logging:
   file:

--- a/src/test/java/com/github/projects/api/ProjectServiceResilienceTest.java
+++ b/src/test/java/com/github/projects/api/ProjectServiceResilienceTest.java
@@ -1,0 +1,91 @@
+package com.github.projects.api;
+
+import com.github.configuration.TestcontainersConfiguration;
+import com.github.projects.exception.CriticalServiceFailureException;
+import com.github.projects.model.AuditMetadata;
+import com.github.projects.model.ProjectDTO;
+import com.github.projects.model.ProjectRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class ProjectServiceResilienceTest extends TestcontainersConfiguration {
+
+    @MockitoBean
+    private ProjectRepository projectRepository;
+
+    @MockitoBean
+    private ProjectCacheService projectCacheService;
+
+    private final ProjectService underTest;
+
+    @Autowired
+    ProjectServiceResilienceTest(ProjectService underTest) {
+        this.underTest = underTest;
+    }
+
+    @Test
+    void shouldFallbackToCache_WhenDatabaseRequestTimesOut() {
+        // Given a project exists in cache but DB request times out
+        ProjectDTO cachedProject = createSampleProject();
+
+        when(projectCacheService.getProjectFromCache(cachedProject.id().toString()))
+                .thenReturn(Mono.empty()) // Cache miss on first attempt
+                .thenReturn(Mono.just(cachedProject)); // Cache fallback should return this
+
+        when(projectRepository.findById(cachedProject.id().toString()))
+                .thenReturn(Flux.just(cachedProject).delayElements(Duration.ofSeconds(3)) // Simulating timeout
+                        .then(Mono.empty()));
+
+        // When requesting the project
+        Mono<ProjectDTO> result = underTest.findById(cachedProject.id().toString());
+
+        // Then it should fall back to the cache
+        StepVerifier.create(result)
+                .expectNext(cachedProject)
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldTriggerCircuitBreakerAndFallback_AfterConsecutiveFailures() {
+        // Given cache service is failing consistently
+        when(projectCacheService.getProjectFromCache(Mockito.anyString()))
+                .thenReturn(Mono.error(new CriticalServiceFailureException("Simulated failure")));
+
+        // Simulate repeated failures to trigger the circuit breaker
+        for (int i = 0; i < 5; i++) {
+            StepVerifier.create(underTest.findById("non-existent-id"))
+                    .expectErrorSatisfies(error ->
+                            assertThat(error).isInstanceOf(CriticalServiceFailureException.class))
+                    .verify();
+        }
+
+        // Now, circuit breaker should be open and fallback should return empty
+        StepVerifier.create(underTest.findById("non-existent-id"))
+                .expectError() // Expecting fallback to return Mono.empty()
+                .verify();
+    }
+
+    private ProjectDTO createSampleProject() {
+        return new ProjectDTO(
+                randomUUID(), "Sample Project", new BigDecimal("100"),
+                new BigDecimal("500"), new AuditMetadata(Instant.now(), Instant.now()), 0L
+        );
+    }
+}


### PR DESCRIPTION
- Implemented @TimeLimiter and @CircuitBreaker in findById to handle timeouts and failures.
- Added fallback methods to retrieve projects from cache when failures occur.
- Introduced ProjectServiceResilienceTest to validate fallback behavior under timeouts and circuit breaker activation.

Fixes #4