### PR TITLE
Add roi.final_capital_with_projects Gauge for capital tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,9 @@ request:
          }'
  ```
 
-To **view selected projects and capital maximization** after receiving a Kafka event, refer to Grafana as described
-in the [Setup for Local Development (Log Monitoring section)](#observability-setup-for-local-development), or check the
-console logs.
-
-_We're currently developing an advanced analytics and graphical representation user interface._
+To **view the selected projects and capital maximization results** after receiving a Kafka event, refer to **Grafana**
+as described in the [Setup for Local Development (Metrics Monitoring)](#observability-setup-for-local-development)
+section. Select the **metric** `roi_final_capital_with_projects`, and for **label filters**, choose `selected_projects`.
 
 ### List all projects
 

--- a/observability/prom-config.yaml
+++ b/observability/prom-config.yaml
@@ -1,6 +1,6 @@
 global:
   scrape_interval: 15s
-  evaluation_interval: 5s
+  evaluation_interval: 15s
   external_labels:
     monitor: 'dev'
 

--- a/observability/prom-config.yaml
+++ b/observability/prom-config.yaml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 5s
+  scrape_interval: 15s
   evaluation_interval: 5s
   external_labels:
     monitor: 'dev'

--- a/src/main/java/com/github/analytics/event/ProjectCapitalOptimizerEventConsumer.java
+++ b/src/main/java/com/github/analytics/event/ProjectCapitalOptimizerEventConsumer.java
@@ -102,7 +102,7 @@ public class ProjectCapitalOptimizerEventConsumer {
                 .collect(Collectors.joining(","));
 
         // Create a Gauge with dynamic labels
-        Gauge.builder("roi.final_capital_with_projects", result::finalCapital) // roi_final_capital_with_projects
+        Gauge.builder("roi.final_capital_with_projects", result::finalCapital)
                 .description("The final maximized capital with selected projects")
                 .tag("selected_projects", selectedProjects)
                 .register(meterRegistry);

--- a/src/main/java/com/github/analytics/event/ProjectCapitalOptimizerEventConsumer.java
+++ b/src/main/java/com/github/analytics/event/ProjectCapitalOptimizerEventConsumer.java
@@ -6,6 +6,8 @@ import com.github.analytics.api.ProjectCapitalOptimizer;
 import com.github.projects.api.ProjectService;
 import com.github.projects.exception.ProjectNotFoundException;
 import com.github.projects.model.ProjectDTO;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -18,6 +20,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 import java.time.Duration;
+import java.util.stream.Collectors;
 
 import static com.github.configuration.KafkaConfiguration.CAPITAL_MAXIMIZATION_QUERY_TOPIC;
 
@@ -29,10 +32,15 @@ import static com.github.configuration.KafkaConfiguration.CAPITAL_MAXIMIZATION_Q
 public class ProjectCapitalOptimizerEventConsumer {
     private static final Logger logger = LoggerFactory.getLogger(ProjectCapitalOptimizerEventConsumer.class);
 
+    private final MeterRegistry meterRegistry;
     private final ProjectService projectService;
     private final ProjectCapitalOptimizer projectCapitalOptimizer;
 
-    public ProjectCapitalOptimizerEventConsumer(ProjectService projectService, ProjectCapitalOptimizer projectCapitalOptimizer) {
+    public ProjectCapitalOptimizerEventConsumer(
+            MeterRegistry meterRegistry,
+            ProjectService projectService,
+            ProjectCapitalOptimizer projectCapitalOptimizer) {
+        this.meterRegistry = meterRegistry;
         this.projectService = projectService;
         this.projectCapitalOptimizer = projectCapitalOptimizer;
     }
@@ -55,8 +63,13 @@ public class ProjectCapitalOptimizerEventConsumer {
                 .retryWhen(Retry.fixedDelay(3, Duration.ofSeconds(2))) // Retry transient failures
                 .doOnError(error -> logger.error("Final failure processing event", error))
                 .onErrorResume(error -> Mono.empty()) // Avoid infinite Kafka retries
-                .subscribe(result -> logger.info("Processing completed. Final capital: {}, Selected projects: {}",
-                        result.finalCapital(), result.selectedProjects().stream().map(ProjectDTO::name).toList())
+                .subscribe(result -> {
+
+                            logger.info("Processing completed. Final capital: {}, Selected projects: {}",
+                                    result.finalCapital(), result.selectedProjects().stream().map(ProjectDTO::name).toList());
+
+                            recordCapitalMaximizedPrometheusMetrics(result);
+                        }
                 );
     }
 
@@ -73,7 +86,25 @@ public class ProjectCapitalOptimizerEventConsumer {
 
                     var query = new CapitalMaximizationQuery(projects, event.maxProjects(), event.initialCapital());
                     return projectCapitalOptimizer.maximizeCapital(query);
+
                 })
                 .doOnError(error -> logger.error("Error during capital maximization process", error));
+    }
+
+    private void recordCapitalMaximizedPrometheusMetrics(ProjectCapitalOptimized result) {
+        if (result == null) {
+            logger.warn("ProjectCapitalOptimized is null.");
+            return;
+        }
+
+        String selectedProjects = result.selectedProjects().stream()
+                .map(ProjectDTO::name)
+                .collect(Collectors.joining(","));
+
+        // Create a Gauge with dynamic labels
+        Gauge.builder("roi.final_capital_with_projects", result::finalCapital) // roi_final_capital_with_projects
+                .description("The final maximized capital with selected projects")
+                .tag("selected_projects", selectedProjects)
+                .register(meterRegistry);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,7 @@ management:
           - health
           - prometheus
           - metrics
+          - info
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
This commit introduces a key enhancement to the ROI Project Planner by adding a Prometheus Gauge metric to track capital maximization results. Key changes include:

- Added `roi.final_capital_with_projects` Gauge in `ProjectCapitalOptimizerEventConsumer` as the primary feature, tracking final capital with `selected_projects` as a label, replacing console-only logging for improved observability.
- Updated `README.md` with clear instructions for viewing results in Grafana, specifying the metric and label filter.
- Adjusted Prometheus scrape interval from 5s to 15s in `prom-config.yaml` for better performance in local development.
- Enabled the `info` endpoint in `application.yaml` to support additional observability features.
- Improved logging grammar: changed "ProjectCapitalOptimized was null" to "ProjectCapitalOptimized is null" for consistency.
- Refactored `ProjectCapitalOptimizerEventConsumer` to include `MeterRegistry` dependency and a dedicated `recordCapitalMaximizedPrometheusMetrics` method.

These changes centralize around enhancing monitoring of capital maximization via Prometheus and Grafana, improving the local development experience.

Fixes #48.