### PR TITLE
feat: Add Cassandra StatefulSet and MicroK8s cluster setup for development

### DIFF
--- a/K8s-MultiNode-Dev-Setup.md
+++ b/K8s-MultiNode-Dev-Setup.md
@@ -1,0 +1,193 @@
+# Local Kubernetes Cluster Setup for Development
+
+We are using [Multipass](https://canonical.com/multipass) and [MicroK8s](https://microk8s.io/) because they enable us to
+**create a multi-node cluster**, allowing us to test our application on **multi-node deployments**. This setup provides
+the ability to evaluate **fault tolerance**, **scalability**, and **reliability**—key aspects we need to verify before
+deploying to an EKS cluster.
+
+**Note:** This setup assumes you are using [Ubuntu](https://ubuntu.com/) as your operating system. On other operating
+systems, you can use tools like [Minikube](https://minikube.sigs.k8s.io), among many others, and follow their simple
+setup instructions.
+
+## Prerequisites
+
+- Ubuntu 24.04 LTS (or similar version)
+- At least 8 GB RAM and 6 vCPUs available (adjust VM specs if less)
+- Internet connection
+
+## Install Multipass
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo snap install multipass
+multipass version
+```
+
+### Create 3 VMs
+
+```bash
+multipass launch -n node1 -c 2 -m 2G -d 10G --cloud-init - <<EOF
+#cloud-config
+package_update: true
+packages:
+  - curl
+  - apt-transport-https
+  - ca-certificates
+  - software-properties-common
+EOF
+
+multipass launch -n node2 -c 2 -m 2G -d 10G --cloud-init - <<EOF
+#cloud-config
+package_update: true
+packages:
+  - curl
+  - apt-transport-https
+  - ca-certificates
+  - software-properties-common
+EOF
+
+multipass launch -n node3 -c 2 -m 2G -d 10G --cloud-init - <<EOF
+#cloud-config
+package_update: true
+packages:
+  - curl
+  - apt-transport-https
+  - ca-certificates
+  - software-properties-common
+EOF
+```
+
+**Note:** If a VM fails to start, check its status with multipass list and ensure your system has sufficient resources.
+
+### Install MicroK8s on Each VM
+
+```bash
+multipass shell node1
+sudo snap install microk8s --classic
+sudo usermod -a -G microk8s $USER
+sudo chown -f -R $USER ~/.kube
+exit
+```
+
+Repeat the above steps for `node2` and `node3`:
+
+### Verify MicroK8s Installation
+
+```bash
+multipass shell node1
+microk8s status --wait-ready
+exit
+```
+
+Repeat for `node2` and `node3`. Ensure the status shows MicroK8s is running on each node.
+
+## Create the MicroK8s Cluster
+
+```bash
+multipass shell node1
+microk8s add-node
+```
+
+This will output a microk8s join command, e.g.:
+
+```text
+microk8s join 10.97.131.27:25000/b6787bcd047139501328b45f733ec945/ad80cfdf6579 --worker
+```
+
+Copy this command (the IP and token will be unique to your setup).
+
+### Join node2 and node3 to the cluster:
+
+On node2:
+
+```bash
+multipass shell node2
+microk8s join 10.97.131.27:25000/b6787bcd047139501328b45f733ec945/ad80cfdf6579 --worker
+exit
+```
+
+On node3:
+
+```bash
+multipass shell node3
+microk8s join 10.97.131.27:25000/978e92007c75f9fce0e1db51a26ec021/ad80cfdf6579 --worker
+exit
+```
+
+## Verify the Cluster
+
+```bash
+multipass shell node1
+microk8s kubectl get nodes
+exit
+```
+
+You should see all three nodes listed with a Ready status.
+
+## Configure Access from Your Host
+
+```bash
+sudo snap install kubectl --classic
+```
+
+Copy the kubeconfig from `node1`:
+
+```bash
+multipass shell node1
+microk8s config > ~/kubeconfig
+exit
+
+# On your local machine
+multipass transfer node1:/home/ubuntu/kubeconfig microk8s-kubeconfig
+mv microk8s-kubeconfig .kube/
+ls -la .kube
+```
+
+### Test Cluster Access:
+
+Update the cluster server IP to the node1 IP address:
+
+```bash
+multipass list
+```
+
+Copy the IP of `node1` (e.g., `10.97.131.27`) and edit `~/.kube/microk8s-kubeconfig` to update the server field:
+
+```yaml
+server: https://10.97.131.27:16443
+```
+
+Then test access:
+
+```bash
+export KUBECONFIG=~/.kube/microk8s-kubeconfig
+kubectl get nodes
+```
+
+### Enable Useful MicroK8s Addons
+
+```bash
+multipass shell node1
+microk8s enable dns storage ingress
+exit
+```
+
+- **dns**: Provides cluster-wide DNS resolution.
+- **storage**: Enables persistent storage with a default storage class.
+- **ingress**: Allows external access to services via an Ingress controller.
+
+## Cleanup (Optional)
+
+```bash
+multipass stop --all
+multipass delete --all
+multipass purge
+```
+
+## Troubleshooting
+
+- **VM not starting:** Check `multipass list` and ensure sufficient CPU/memory (e.g., reduce `-c` or `-m` values).
+- **Cluster not forming:** Verify network connectivity between VMs and re-run `microk8s join` if needed.
+- **kubectl errors:** Ensure your local `kubectl` version is compatible with MicroK8s (check with
+  `microk8s kubectl version`).
+- **Still having issues?** Please reach out by opening an issue on GitHub if you encounter any problems with this setup!

--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ Prometheus, Grafana, and Jaeger handle metrics, monitoring, and distributed trac
 control, implement SSL/TLS encryption, and configure auto-scaling for resilience. Additionally, log files are stored in
 Amazon S3 for long-term retention and easy access.
 
+### Local Deployment
+
+For local development and testing, you can set up a **multi-node Kubernetes** cluster using **Multipass** and
+**MicroK8s**. Follow the detailed instructions in [K8s-MultiNode-Dev-Setup.md](./K8s-MultiNode-Dev-Setup.md) to
+configure your environment.
+
+### AWS EKS Deployment
+
 _(Terraform project link will be available soon.)_
 
 ---

--- a/k8s/cassandra-statefulset.yaml
+++ b/k8s/cassandra-statefulset.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cassandra
+  namespace: roi-project-planner-dev
+  labels:
+    app: cassandra
+spec:
+  serviceName: cassandra
+  replicas: 3
+  selector:
+    matchLabels:
+      app: cassandra
+  template:
+    metadata:
+      labels:
+        app: cassandra
+    spec:
+      terminationGracePeriodSeconds: 1800
+      containers:
+        - name: cassandra
+          image: cassandra:5.0.3
+          ports:
+            - containerPort: 7000
+              name: intra-node
+            - containerPort: 7001
+              name: tls-intra-node
+            - containerPort: 9042
+              name: cql
+          resources:
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/bin/sh", "-c", "nodetool drain" ]
+          env:
+            - name: MAX_HEAP_SIZE
+              value: "2048M"
+            - name: HEAP_NEWSIZE
+              value: "512M"
+            - name: CASSANDRA_SEEDS
+              value: "cassandra-0.cassandra.roi-project-planner-dev.svc.cluster.local"
+            - name: CASSANDRA_CLUSTER_NAME
+              value: "MyAppCluster"
+            - name: CASSANDRA_DC
+              value: "DC1"
+            - name: CASSANDRA_RACK
+              value: "Rack1"
+          volumeMounts:
+            - name: cassandra-data
+              mountPath: /var/lib/cassandra
+          livenessProbe:
+            tcpSocket:
+              port: 9042
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 9042
+            initialDelaySeconds: 60
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: cassandra-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 50Gi
+        storageClassName: standard
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cassandra
+  namespace: roi-project-planner-dev
+  labels:
+    app: cassandra
+spec:
+  clusterIP: None
+  ports:
+    - port: 9042
+      name: cql
+  selector:
+    app: cassandra

--- a/k8s/microks-storage.yaml
+++ b/k8s/microks-storage.yaml
@@ -1,0 +1,9 @@
+# Storage configuration for application testing in a MicroK8s cluster
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+provisioner: microk8s.io/hostpath
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: roi-project-planner-dev
+  labels:
+    environment: dev


### PR DESCRIPTION
- Added a StatefulSet definition for Cassandra with 3 replicas, resource limits, probes, and persistent storage.
- Configured a headless Service for Cassandra to enable intra-cluster communication.
- Created a Kubernetes Namespace (`roi-project-planner-dev`) for isolation.
- Defined a StorageClass for persistent volumes using MicroK8s.
- Documented a step-by-step guide for setting up a local MicroK8s cluster with Multipass.
- Included troubleshooting tips and cleanup instructions for managing the development environment.

This setup ensures a scalable and fault-tolerant testing environment before deploying to EKS.