### PR TITLE
feat(kubernetes): Fortify multi-node dev setup with secure secrets and observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 logs/
+kubernetes/cassandra-secrets.yaml
 kubernetes/redis-secrets.yaml
+kubernetes/kafka-secrets.yaml
 
 ### STS ###
 .apt_generated

--- a/K8s-MultiNode-Dev-Setup.md
+++ b/K8s-MultiNode-Dev-Setup.md
@@ -169,13 +169,14 @@ kubectl get nodes
 
 ```bash
 multipass shell node1
-microk8s enable dns storage ingress
+microk8s enable dns storage ingress metrics-server
 exit
 ```
 
 - **dns**: Provides cluster-wide DNS resolution.
 - **storage**: Enables persistent storage with a default storage class.
 - **ingress**: Allows external access to services via an Ingress controller.
+- **metrics-server**: Provides resource usage metrics for HPA.
 
 ## Cleanup (Optional)
 

--- a/README.md
+++ b/README.md
@@ -100,21 +100,40 @@ For local development and testing, you can set up a **multi-node Kubernetes** cl
 configure your environment.
 
 ```bash
-# Create namespace
-kubectl apply -f kubernetes/namespace.yaml 
+# Deploy Kubernetes Resources for Cassandra, Redis, and Kafka Clusters
 
-# Create MicroK8s storage (use preferred storage for non-MicroK8s setups)
-kubectl apply -f kubernetes/microks-storage.yaml
+# 1. Create the namespace
+kubectl apply -f kubernetes/namespace.yaml
 
-# Deploy 3 Apache Cassandra database nodes in a multi-node cluster
+# 2. Configure MicroK8s storage (replace with preferred storage class for non-MicroK8s environments)
+kubectl apply -f kubernetes/microk8s-storage.yaml
+
+# Deploy Cassandra Cluster and Its Secret
+
+# 1. Generate Cassandra credentials (example):
+echo -n "admin" | base64              # Outputs: YWRtaW4=
+echo -n "adminSecureSecret" | base64  # Outputs: YWRtaW5TZWN1cmVTZWNyZXQ=
+
+# 2. Create and apply cassandra-secrets.yaml:
+echo "apiVersion: v1
+kind: Secret
+metadata:
+  name: cassandra-secrets
+  namespace: roi-project-planner-dev
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: YWRtaW5TZWN1cmVTZWNyZXQ=" > kubernetes/cassandra-secrets.yaml
+kubectl apply -f kubernetes/cassandra-secrets.yaml
+
+# 3. Deploy the Cassandra cluster:
 kubectl apply -f kubernetes/cassandra-statefulset.yaml
 
-# Deploy Redis and Its Secret
+# Deploy Redis Cluster and Its Secret
+# 1. Generate the Redis password (example):
+echo -n "secret" | base64             # Outputs: c2VjcmV0
 
-# First, generate the Redis password. For example:
-echo -n "secret" | base64
-
-# Second, create and deploy redis-secrets.yaml:
+# 2. Create and apply redis-secrets.yaml:
 echo "apiVersion: v1
 kind: Secret
 metadata:
@@ -125,7 +144,7 @@ data:
   password: c2VjcmV0" > kubernetes/redis-secrets.yaml
 kubectl apply -f kubernetes/redis-secrets.yaml
 
-# Finally, deploy the Redis database:
+# 3. Deploy the Redis cluster:
 kubectl apply -f kubernetes/redis-deployment.yaml
 
 ```

--- a/kubernetes/cassandra-statefulset.yaml
+++ b/kubernetes/cassandra-statefulset.yaml
@@ -1,3 +1,6 @@
+# Cassandra uses a StatefulSet to provide stable identities and persistent storage, enabling a
+# multi-node cluster with 3 replicas for production-grade scalability and fault tolerance.
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -51,6 +54,16 @@ spec:
               value: "DC1"
             - name: CASSANDRA_RACK
               value: "Rack1"
+            - name: CASSANDRA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cassandra-secrets
+                  key: username
+            - name: CASSANDRA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cassandra-secrets
+                  key: password
           volumeMounts:
             - name: cassandra-data
               mountPath: /var/lib/cassandra


### PR DESCRIPTION
This commit advances the ROI Project Planner's Kubernetes multi-node development environment by implementing robust secret management, enhancing observability, and optimizing deployment workflows. These changes establish a secure, scalable foundation for local testing and future production readiness. Key updates:

- **.gitignore**: Excluded `kubernetes/{cassandra,kafka}-secrets.yaml` to safeguard sensitive credentials from version control, aligning with security best practices and reducing leak risk.
- **K8s-MultiNode-Dev-Setup.md**: Activated `metrics-server` in MicroK8s alongside `dns`, `storage`, and `ingress`. This enables resource utilization tracking for HorizontalPodAutoscaler (HPA), critical for performance tuning and capacity planning.
- **README.md**: Overhauled deployment instructions for precision and developer empowerment:
  - Added explicit steps for generating and applying base64-encoded secrets for Cassandra, with examples (`admin:adminSecureSecret`).
  - Clarified Redis and Cassandra deployments as clustered setups, emphasizing scalability over single-instance assumptions.
  - Improved readability with numbered steps and consistent formatting.
- **kubernetes/cassandra-statefulset.yaml**: Augmented the StatefulSet with:
  - Secure credential injection via `cassandra-secrets` Secret, using `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD` env vars.
  - Detailed comments justifying StatefulSet usage: stable pod identities and persistent storage for a 3-replica cluster, ensuring fault tolerance and data consistency.

**Impact**: These enhancements mitigate security risks, improve cluster observability, and streamline onboarding for engineers. Validated on a 3-node MicroK8s cluster, confirming seamless Cassandra pod startup with secrets and metrics availability via `kubectl top`.

**Next Steps**: Consider integrating Kafka secrets and a Helm chart for production deployments.