### PR TITLE
Add pod anti-affinity for high availability to spread Cassandra pods across nodes

### DIFF
--- a/kubernetes/cassandra-statefulset.yaml
+++ b/kubernetes/cassandra-statefulset.yaml
@@ -1,6 +1,3 @@
-# Cassandra uses a StatefulSet to provide stable identities and persistent storage, enabling a
-# multi-node cluster with 3 replicas for production-grade scalability and fault tolerance.
-
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -19,6 +16,16 @@ spec:
       labels:
         app: cassandra
     spec:
+      # Anti-affinity to spread Cassandra pods across nodes for HA
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values: ["cassandra"]
+              topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 1800
       containers:
         - name: cassandra
@@ -40,7 +47,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: [ "/bin/sh", "-c", "nodetool drain" ]
+                command: ["/bin/sh", "-c", "nodetool drain"]
           env:
             - name: MAX_HEAP_SIZE
               value: "2048M"
@@ -81,7 +88,7 @@ spec:
     - metadata:
         name: cassandra-data
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         resources:
           requests:
             storage: 50Gi


### PR DESCRIPTION
- Implemented pod anti-affinity to spread Cassandra pods across nodes for high availability.
- Fixed YAML formatting issues, including space consistency and minor command adjustments.