### PR TITLE
feat(k8s): add roi-project-planner deployment with config, service, and HPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+
 logs/
 kubernetes/cassandra-secrets.yaml
 kubernetes/redis-secrets.yaml
 kubernetes/kafka-secrets.yaml
+kubernetes/roi-project-planner-secrets.yaml
 
 ### STS ###
 .apt_generated

--- a/K8s-MultiNode-Dev-Setup.md
+++ b/K8s-MultiNode-Dev-Setup.md
@@ -139,8 +139,8 @@ microk8s config > ~/kubeconfig
 exit
 
 # On your local machine
-multipass transfer node1:/home/ubuntu/kubeconfig microk8s-kubeconfig
-mv microk8s-kubeconfig .kube/
+multipass transfer node1:/home/ubuntu/kubeconfig config
+mv config .kube/
 ls -la .kube
 ```
 
@@ -152,7 +152,7 @@ Update the cluster server IP to the node1 IP address:
 multipass list
 ```
 
-Copy the IP of `node1` (e.g., `10.97.131.27`) and edit `~/.kube/microk8s-kubeconfig` to update the server field:
+Copy the IP of `node1` (e.g., `10.97.131.27`) and edit `~/.kube/config` to update the server field:
 
 ```yaml
 server: https://10.97.131.27:16443
@@ -161,7 +161,7 @@ server: https://10.97.131.27:16443
 Then test access:
 
 ```bash
-export KUBECONFIG=~/.kube/microk8s-kubeconfig
+export KUBECONFIG=~/.kube/config
 kubectl get nodes
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ kubectl apply -f kubernetes/cassandra-statefulset.yaml
 
 # Deploy Redis Cluster and Its Secret
 # 1. Generate the Redis password (example):
-echo -n "secret" | base64             # Outputs: c2VjcmV0
+echo -n "adminSecureSecret" | base64  # Outputs: YWRtaW5TZWN1cmVTZWNyZXQ=
 
 # 2. Create and apply redis-secrets.yaml:
 echo "apiVersion: v1
@@ -148,8 +148,29 @@ kubectl apply -f kubernetes/redis-secrets.yaml
 kubectl apply -f kubernetes/redis-deployment.yaml
 
 # Deploy Kafka Cluster and Its Secret
-
 kubectl apply -f kubernetes/kafka-statefulset.yaml
+
+# Deploy the roi-project-planner and its secrets
+
+# 1. Generate roi-project-planner database connection details:
+
+echo "apiVersion: v1
+kind: Secret
+metadata:
+  name: roi-project-planner-secrets
+  namespace: roi-project-planner-dev
+type: Opaque
+data:
+  cassandra-username: YWRtaW4=
+  cassandra-password: YWRtaW5TZWN1cmVTZWNyZXQ=
+  redis-password: YWRtaW5TZWN1cmVTZWNyZXQ=
+  kafka-username: YWRtaW4=
+  kafka-password: YWRtaW5TZWN1cmVTZWNyZXQ=" > kubernetes/roi-project-planner-secrets.yaml
+kubectl apply -f kubernetes/roi-project-planner-secrets.yaml 
+
+# 2. # Deploy the roi-project-planner
+
+kubectl apply -f kubernetes/roi-project-planner-deployment.yaml
 
 ```
 

--- a/kubernetes/cassandra-statefulset.yaml
+++ b/kubernetes/cassandra-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: cassandra
     spec:
-      # Anti-affinity to spread Cassandra pods across nodes for HA
+      # Anti-affinity to spread brokers across nodes
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -24,7 +24,7 @@ spec:
                 matchExpressions:
                   - key: app
                     operator: In
-                    values: ["cassandra"]
+                    values: [ "cassandra" ]
               topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 1800
       containers:
@@ -47,7 +47,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "nodetool drain"]
+                command: [ "/bin/sh", "-c", "nodetool drain" ]
           env:
             - name: MAX_HEAP_SIZE
               value: "2048M"
@@ -88,7 +88,7 @@ spec:
     - metadata:
         name: cassandra-data
       spec:
-        accessModes: ["ReadWriteOnce"]
+        accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:
             storage: 50Gi

--- a/kubernetes/roi-project-planner-deployment.yaml
+++ b/kubernetes/roi-project-planner-deployment.yaml
@@ -1,0 +1,195 @@
+# ConfigMap for application configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: roi-project-planner-config
+  namespace: roi-project-planner-dev
+data:
+  application-dev.yml: |
+    spring:
+      application:
+        name: roi-project-planner
+      cloud:
+        stream:
+          kafka:
+            binder:
+              brokers: kafka-bootstrap.roi-project-planner-dev.svc.cluster.local:9092
+              configuration:
+                sasl.mechanism: PLAIN
+                security.protocol: SASL_PLAINTEXT
+                sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="${KAFKA_USERNAME}" password="${KAFKA_PASSWORD}";
+      data:
+        redis:
+          host: redis.roi-project-planner-dev.svc.cluster.local
+          port: 6379
+          password: ${REDIS_PASSWORD}
+        cassandra:
+          contact-points: cassandra.roi-project-planner-dev.svc.cluster.local
+          port: 9042
+          local-datacenter: DC1
+          username: ${CASSANDRA_USERNAME}
+          password: ${CASSANDRA_PASSWORD}
+    management:
+      tracing:
+        exporter:
+          zipkin:
+            endpoint: http://zipkin.roi-project-planner-dev.svc.cluster.local:9411/api/v2/spans
+    logging:
+      file:
+        path: /var/log/app
+        name: application.log
+
+---
+
+# Service for roi-project-planner application
+apiVersion: v1
+kind: Service
+metadata:
+  name: roi-project-planner-service
+  namespace: roi-project-planner-dev
+  labels:
+    app: roi-project-planner
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+  selector:
+    app: roi-project-planner
+
+---
+
+# Deployment for roi-project-planner application
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: roi-project-planner
+  namespace: roi-project-planner-dev
+  labels:
+    app: roi-project-planner
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: roi-project-planner
+  template:
+    metadata:
+      labels:
+        app: roi-project-planner
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values: [ "roi-project-planner" ]
+              topologyKey: "kubernetes.io/hostname"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: roi-project-planner
+          image: ranzyblessingsdocker/roi-project-planner:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "dev"
+            - name: JAVA_OPTS
+              value: "-Xmx512m -Xms256m"
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: roi-project-planner-secrets
+                  key: kafka-username
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: roi-project-planner-secrets
+                  key: kafka-password
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: roi-project-planner-secrets
+                  key: redis-password
+            - name: CASSANDRA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: roi-project-planner-secrets
+                  key: cassandra-username
+            - name: CASSANDRA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: roi-project-planner-secrets
+                  key: cassandra-password
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "0.5"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+            - name: log-storage
+              mountPath: /var/log/app
+      volumes:
+        - name: config-volume
+          configMap:
+            name: roi-project-planner-config
+        - name: log-storage
+          emptyDir: { }
+
+---
+
+# HorizontalPodAutoscaler
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: roi-project-planner-hpa
+  namespace: roi-project-planner-dev
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: roi-project-planner
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80


### PR DESCRIPTION
Introduce Kubernetes manifests for deploying the roi-project-planner Spring Boot application in the roi-project-planner-dev namespace. This commit includes:

- ConfigMap (roi-project-planner-config): Defines application configuration for Kafka, Redis, and Cassandra integration, using headless service DNS for dynamic discovery and Secrets for credentials.
- Service (roi-project-planner-service): Exposes the app on port 8080 via ClusterIP for internal access.
- Deployment (roi-project-planner): Deploys 3 replicas of ranzyblessingsdocker/roi-project-planner:latest with pod anti-affinity for HA, resource requests/limits, readiness/liveness probes, and non-root security context.
- HorizontalPodAutoscaler (roi-project-planner-hpa): Scales between 3-10 replicas based on CPU (70%) and memory (80%) utilization for load adaptability.

These resources establish a production-ready foundation with high availability, scalability, and observability, aligning with best practices for stateful and stateless workloads.