### PR TITLE
feat(kubernetes): Update health probe paths and improve README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Amazon S3 for long-term retention and easy access.
 
 ### Local Deployment
 
-For local development and testing, you can set up a **multi-node Kubernetes** cluster using **Multipass** and
+For local development and testing, you can set up a **multi-node Kubernetes cluster** using **Multipass** and
 **MicroK8s**. Follow the detailed instructions in [K8s-MultiNode-Dev-Setup.md](./K8s-MultiNode-Dev-Setup.md) to
 configure your environment.
 

--- a/kubernetes/roi-project-planner-deployment.yaml
+++ b/kubernetes/roi-project-planner-deployment.yaml
@@ -141,14 +141,14 @@ spec:
               cpu: "1"
           readinessProbe:
             httpGet:
-              path: /actuator/health/readiness
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /actuator/health/liveness
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 20


### PR DESCRIPTION
- Updated readiness and liveness probe paths in `roi-project-planner-deployment.yaml` to use a simplified `/actuator/health` endpoint.
- Improved README wording for local Kubernetes cluster setup instructions.